### PR TITLE
use the standard way to find shared libraries on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,38 @@ It is also possible to install directly from the GitHub repository. You will nee
 ```bash
 pip install git+https://github.com/ofmla/seiscope_opt_toolbox_w_ctypes
 ```
+
+## Quick install of the sotb library and its Python wrapper
+
+Compile the SOTB library using CMake.
+
+```bash
+cd seiscope_opt_toolbox_w_ctypes
+cmake -S. -Bbuild
+cmake --build build
+cmake --install build --prefix=/usr/local/sotb
+```
+
+Add library path to the environment variable `LD_LIBRARY_PATH`
+
+```bash
+export LD_LIBRARY_PATH=/usr/local/sotb:$LD_LIBRARY_PATH
+```
+
+Install the Python wrapper
+
+```
+pip3 install .
+```
+
+Run tests
+
+```bash
+# if not installed install py.test using: pip3 install pytest
+py.test test
+```
+
+
 ### Usage
 
 The following example demonstrates how to define and solve the classical Rosenbrock problem

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ cmake --install build --prefix=/usr/local/sotb
 Add library path to the environment variable `LD_LIBRARY_PATH`
 
 ```bash
-export LD_LIBRARY_PATH=/usr/local/sotb:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=/usr/local/sotb/lib:$LD_LIBRARY_PATH
 ```
 
 Install the Python wrapper

--- a/sotb_wrapper/interface.py
+++ b/sotb_wrapper/interface.py
@@ -111,14 +111,15 @@ class UserDefined(ctypes.Structure):
 
 
 # Load shared library
-path = Path(__file__).parent
 name = "libsotb"
 name = f"{name}.so"
 
 # This is how a dll/so library is loaded
 try:
-
-    lib_sotb = ctypes.CDLL(str(path / name), winmode=0)
+    # the path containing the library 
+    # "libsotb.so" must be present on the variable LD_LIBRARY_PATH
+    # for instance LD_LIBRARY_PATH=/usr/local/sotb/lib:$LD_LIBRARY_PATH
+    lib_sotb = ctypes.CDLL(name, winmode=0)
 
 except Exception as e:
 


### PR DESCRIPTION
use the standard way to find shared libraries on Linux (LD_LIBRARY_PATH) and update the documentation